### PR TITLE
GH Actions improvements and fixes:

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,6 +3,9 @@ name: Docker Image CI
 on:
   pull_request:
     branches: [ "main" ]
+  push:
+    tags-ignore: ["*"]
+  workflow_dispatch:
 
 jobs:
 
@@ -12,10 +15,13 @@ jobs:
 
     steps:
     - name: 'Checkout Actions'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 5
+        fetch-tags: true
 
     - name: 'Build the Docker image'
-      run: make docker
+      run: IMAGE_REPO=ghcr.io make docker
 
     - name: 'Test the Docker image'
-      run: make docker_test
+      run: IMAGE_REPO=ghcr.io make docker_test

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
 
 jobs:
 
@@ -13,7 +14,7 @@ jobs:
 
     steps:
     - name: 'Checkout Actions'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: 'Login to GitHub Container Registry'
       uses: docker/login-action@v3
@@ -23,10 +24,10 @@ jobs:
         password: ${{secrets.GITHUB_TOKEN}}
 
     - name: 'Build the Docker image'
-      run: make docker
+      run: IMAGE_REPO="ghcr.io" make docker
 
     - name: 'Test the Docker image'
-      run: make docker_test
+      run: IMAGE_REPO="ghcr.io" make docker_test
 
     - name: 'Release the Docker image'
-      run: IMAGE_REPOSITORY=ghcr.io make docker_release
+      run: IMAGE_REPO="ghcr.io" make docker_release


### PR DESCRIPTION
 - image_build fix: ignore tags
   - when a tag is pushed, the same issue as fixed in d7644ac occurs, because the tag push also triggers an image build via the push trigger
   - it follows, that the image build should ignore tag pushes, since the tag push also builds it's own image, and thus the image-build workflow becomes unnecessary and redundant
   - we do this by telling the push trigger to ignore-tags

 - release_build fix
   - Fix: "Error: fatal: Cannot fetch both ...3fe48ceaf and refs/tags/v0.2.12 to refs/tags/v0.2.12
   - If a tag is being pushed, the checkout directive with: fetch-tags: true causes this error
   - Since the release build is triggered by a tag, the checkout step "automagically" also clones tags, and the release build works without the with: fetch-tags, and fails per above with that directive
   - bit counter-intuitive, and seems to be a recent fix, that does not document this quirk

 - Update GH actions: set the image repo, update API calls to v4